### PR TITLE
fix for pitch detection on android

### DIFF
--- a/android/src/main/java/com/example/pitchdetector/PitchdetectorPlugin.java
+++ b/android/src/main/java/com/example/pitchdetector/PitchdetectorPlugin.java
@@ -132,7 +132,7 @@ public class PitchdetectorPlugin implements FlutterPlugin, MethodCallHandler {
               float pitchResult =  pitchHandler.getPitch(samples);
               try {
                 if(pitchResult != -1.0){
-                  channel.invokeMethod("getPitch", samples);
+                  channel.invokeMethod("getPitch", pitchResult);
                 }
                 findPitch(audioRecorder , recording);
                   // SENDS ARRAY "returnData" BACK TO FLUTTER


### PR DESCRIPTION
fix for return type on getPitch for android to return the pitch as double and not the samples array of floats